### PR TITLE
add a 90m timeout to image builds

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     env:
       DOCKER_CONFIG: $HOME/.docker
       IMAGE: ${{ vars.IMAGE }}

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   test-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     env:
       DOCKER_CONFIG: $HOME/.docker
     steps:


### PR DESCRIPTION
yesterday, a biology image build was stuck for ~2hrs and i had to manually kill it.  so, let's add timeouts to the image builds.  :)